### PR TITLE
Add `using POMDPs` in README example for the method `actions`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Supports CPU and GPU computation and implements deep reinforcement learning, imi
 An example usage of the `REINFORCE` algorithm with a simple Flux network for the Cart Pole problem is shown here:
 
 ```julia
-using Crux, POMDPGym
+using Crux, POMDPGym, POMDPs
 
 # Problem setup
 mdp = GymPOMDP(:CartPole)


### PR DESCRIPTION
This prevents the error

    UndefVarError: `actions` not defined in `Main`